### PR TITLE
Fix issue 110: Remove unneeded declaration for MSC

### DIFF
--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -30,7 +30,6 @@
 #endif
 #include <boost/iterator/counting_iterator.hpp>
 #ifdef _MSC_VER
-    template ::boost::counting_iterator<int>;
     #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
Declaration "template ::boost::counting_iterator<int>;" is not needed on Windows. 
The declaration is also not acceptible with latest clang-cl compiler.